### PR TITLE
Make AppControllerTestCase::assertIsA static

### DIFF
--- a/Lib/AppControllerTestCase.php
+++ b/Lib/AppControllerTestCase.php
@@ -230,7 +230,7 @@ class AppControllerTestCase extends ControllerTestCase {
 	}
 
 	
-	public function assertIsA($actual, $expected, $message = '') {
+	public static function assertIsA($actual, $expected, $message = '') {
 		self::assertType($expected, $actual, $message);
 	}
 

--- a/Lib/AppTestCase.php
+++ b/Lib/AppTestCase.php
@@ -229,7 +229,7 @@ class AppTestCase extends CakeTestCase {
 	}
 
 	
-	public function assertIsA($actual, $expected, $message = '') {
+	public static function assertIsA($actual, $expected, $message = '') {
 		self::assertType($expected, $actual, $message);
 	}
 


### PR DESCRIPTION
This fixes the following error as the parent method ControllerTestCase::assertIsA() is static.

```
Error: Cannot make static method CakeTestCase::assertIsA() non static in class AppControllerTestCase    
File: /var/www/cake2plugins/Templates/Lib/AppControllerTestCase.php 
Line: 19
```

Thanks!

EDIT: Oh and `AppTestCase::assertIsA()` as well.
