### PR TITLE
Fixing __constructor to be initialized as the parent constructor.

### DIFF
--- a/Lib/AppTestCase.php
+++ b/Lib/AppTestCase.php
@@ -55,8 +55,8 @@ class AppTestCase extends CakeTestCase {
  *
  * @return void
  */
-	public function __construct() {
-		parent::__construct();
+	public function __construct($name = null, array $data = array(), $dataName = '') {
+		parent::__construct($name, $data, $dataName);
 		if (is_subclass_of($this, 'AppTestCase')) {
 			$parentClass = get_parent_class($this);
 			$parentVars = get_class_vars($parentClass);


### PR DESCRIPTION
fixing constructor from AppTestCase to be initialized exactly as the parent constructor, so this will solve the problem with dataProvider and so on.
